### PR TITLE
`PROMETHEUS_METRICS_PROVIDER` should be present

### DIFF
--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -147,7 +147,7 @@ try:
 
     __all__ += ("PROMETHEUS_METRICS_PROVIDER", "PrometheusMetricsProvider")
 except ImportError:
-    pass
+    PROMETHEUS_METRICS_PROVIDER = None
 
 try:
     import opentelemetry.propagate

--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -145,9 +145,10 @@ try:
 
     from .prometheus import PROMETHEUS_METRICS_PROVIDER, PrometheusMetricsProvider
 
-    __all__ += ("PROMETHEUS_METRICS_PROVIDER", "PrometheusMetricsProvider")
+    __all__ += ("PrometheusMetricsProvider",)
 except ImportError:
     PROMETHEUS_METRICS_PROVIDER = None
+__all__ += ("PROMETHEUS_METRICS_PROVIDER",)
 
 try:
     import opentelemetry.propagate


### PR DESCRIPTION
Otherwise, one should handle `AttributeError` in case `prometheus_client` is absent in third service