### PR TITLE
Do not expect json content type

### DIFF
--- a/aio_request/aiohttp.py
+++ b/aio_request/aiohttp.py
@@ -192,7 +192,7 @@ class _AioHttpResponse(ClosableResponse):
         *,
         encoding: Optional[str] = None,
         loads: Callable[[str], Any] = json.loads,
-        content_type: Optional[str] = "application/json",
+        content_type: Optional[str] = None,
     ) -> Any:
         return await self._response.json(encoding=encoding, loads=loads, content_type=content_type)
 

--- a/aio_request/base.py
+++ b/aio_request/base.py
@@ -189,7 +189,7 @@ class EmptyResponse(ClosableResponse):
         *,
         encoding: Optional[str] = None,
         loads: Optional[Callable[[str], Any]] = None,
-        content_type: Optional[str] = "application/json",
+        content_type: Optional[str] = None,
     ) -> Any:
         return None
 

--- a/aio_request/base.py
+++ b/aio_request/base.py
@@ -188,7 +188,7 @@ class EmptyResponse(ClosableResponse):
         self,
         *,
         encoding: Optional[str] = None,
-        loads: Optional[Callable[[str], Any]] = None,
+        loads: Optional[Callable[[str], Any]] = json.loads,
         content_type: Optional[str] = None,
     ) -> Any:
         return None


### PR DESCRIPTION
By default, `Response.json()` inherits behaviour of `aiohttp` and expects `application/json` content type. So, in the case of a response with json in its body but without content type headers, an exception will be raised.

IMHO, it is too strict requirement especially and it is fine to expect nothing by default.