### PR TITLE
URLEncode path_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.24 (2022-07-04)
+
+* [URL-encode path_parameters](https://github.com/anna-money/aio-request/pull/146)
+
+
 ## v0.1.23 (2022-02-08)
 
 * [Reject throttling(too many requests) status code](https://github.com/anna-money/aio-request/pull/123)

--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -161,7 +161,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.1.23"
+__version__ = "0.1.24"
 
 version = f"{__version__}, Python {sys.version}"
 

--- a/aio_request/base.py
+++ b/aio_request/base.py
@@ -259,13 +259,13 @@ def substitute_path_parameters(url: yarl.URL, parameters: Optional[PathParameter
 
     build_parameters: Dict[str, Any] = dict(
         scheme=url.scheme,
-        user=url.user,
-        password=url.password,
-        host=url.host,
+        user=url.raw_user,
+        password=url.raw_password,
+        host=url.raw_host,
         port=url.port,
         path=path,
-        query=url.query,
-        fragment=url.fragment,
+        query_string=url.raw_query_string,
+        fragment=url.raw_fragment,
     )
 
     return yarl.URL.build(**{k: v for k, v in build_parameters.items() if v is not None}, encoded=True)

--- a/aio_request/base.py
+++ b/aio_request/base.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import re
+import urllib.parse
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import multidict
@@ -254,7 +255,7 @@ def substitute_path_parameters(url: yarl.URL, parameters: Optional[PathParameter
 
     path = url.path
     for name, value in parameters.items():
-        path = path.replace(f"{{{name}}}", str(value))
+        path = path.replace(f"{{{name}}}", urllib.parse.quote(str(value), safe=""))
 
     build_parameters: Dict[str, Any] = dict(
         scheme=url.scheme,
@@ -267,4 +268,4 @@ def substitute_path_parameters(url: yarl.URL, parameters: Optional[PathParameter
         fragment=url.fragment,
     )
 
-    return yarl.URL.build(**{k: v for k, v in build_parameters.items() if v is not None})
+    return yarl.URL.build(**{k: v for k, v in build_parameters.items() if v is not None}, encoded=True)

--- a/aio_request/base.py
+++ b/aio_request/base.py
@@ -253,9 +253,9 @@ def substitute_path_parameters(url: yarl.URL, parameters: Optional[PathParameter
     if not parameters:
         return url
 
-    path = url.path
+    path = url.raw_path
     for name, value in parameters.items():
-        path = path.replace(f"{{{name}}}", urllib.parse.quote(str(value), safe=""))
+        path = path.replace(f"%7B{name}%7D", urllib.parse.quote(str(value), safe=""))
 
     build_parameters: Dict[str, Any] = dict(
         scheme=url.scheme,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ from aio_request.base import QueryParameters, build_query_parameters, substitute
         (yarl.URL("https://site.com/{a}"), {"a": "1"}, yarl.URL("https://site.com:443/1")),
         (yarl.URL("{a}/do?b=2"), {"a": "x/y"}, yarl.URL("x%2Fy/do?b=2")),
         (yarl.URL("{a}/do%2Fsmth/?b=!%2F^"), {"a": "x/y"}, yarl.URL("x%2Fy/do%2Fsmth/?b=!%2F^")),
+        (yarl.URL("{a}/do%2Fsmth/?b=!%2F^#%2F"), {"a": "x/y"}, yarl.URL("x%2Fy/do%2Fsmth/?b=!%2F^#%2F")),
     ],
 )
 def test_substitute_path_parameters(url: yarl.URL, parameters: Optional[Dict[str, str]], result: yarl.URL) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@ from aio_request.base import QueryParameters, build_query_parameters, substitute
         (yarl.URL("do/{a}"), {"a": "1"}, yarl.URL("do/1")),
         (yarl.URL("https://site.com/"), {}, yarl.URL("https://site.com/")),
         (yarl.URL("https://site.com/{a}"), {"a": "1"}, yarl.URL("https://site.com:443/1")),
+        (yarl.URL("{a}/do?b=2"), {"a": "x/y"}, yarl.URL("x%2Fy/do?b=2")),
     ],
 )
 def test_substitute_path_parameters(url: yarl.URL, parameters: Optional[Dict[str, str]], result: yarl.URL) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,11 @@ from aio_request.base import QueryParameters, build_query_parameters, substitute
         (yarl.URL("{a}/do?b=2"), {"a": "x/y"}, yarl.URL("x%2Fy/do?b=2")),
         (yarl.URL("{a}/do%2Fsmth/?b=!%2F^"), {"a": "x/y"}, yarl.URL("x%2Fy/do%2Fsmth/?b=!%2F^")),
         (yarl.URL("{a}/do%2Fsmth/?b=!%2F^#%2F"), {"a": "x/y"}, yarl.URL("x%2Fy/do%2Fsmth/?b=!%2F^#%2F")),
+        (
+            yarl.URL("abc/{a}/xyz"),
+            {"a": "88FBDCCF-2096-40BF-A2D3-568DE949F40C"},
+            yarl.URL("abc/88FBDCCF-2096-40BF-A2D3-568DE949F40C/xyz"),
+        ),
     ],
 )
 def test_substitute_path_parameters(url: yarl.URL, parameters: Optional[Dict[str, str]], result: yarl.URL) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from aio_request.base import QueryParameters, build_query_parameters, substitute
         (yarl.URL("https://site.com/"), {}, yarl.URL("https://site.com/")),
         (yarl.URL("https://site.com/{a}"), {"a": "1"}, yarl.URL("https://site.com:443/1")),
         (yarl.URL("{a}/do?b=2"), {"a": "x/y"}, yarl.URL("x%2Fy/do?b=2")),
+        (yarl.URL("{a}/do%2Fsmth/?b=!%2F^"), {"a": "x/y"}, yarl.URL("x%2Fy/do%2Fsmth/?b=!%2F^")),
     ],
 )
 def test_substitute_path_parameters(url: yarl.URL, parameters: Optional[Dict[str, str]], result: yarl.URL) -> None:


### PR DESCRIPTION
Fixes this situation:
```python
aio_request.get("some_api/{some_path_value}", path_parameters={"some_path_value": "xxx/yyy"})
# leads to request with wrong path "some_api/xxx/yyy" instead of correct path "some_api/xxx%2Fyyy"
```