### PR TITLE
Fix datetime.now deprecation

### DIFF
--- a/aio_request/deadline.py
+++ b/aio_request/deadline.py
@@ -20,10 +20,10 @@ class Deadline:
     deadline_at: datetime.datetime
 
     def __init__(self, deadline_at: datetime.datetime):
-        if deadline_at.tzinfo is not None:
-            raise RuntimeError("Deadline should not be zone aware")
-
-        self.deadline_at = deadline_at
+        if deadline_at.tzinfo is None:
+            self.deadline_at = deadline_at.replace(tzinfo=datetime.timezone.utc)
+        else:
+            self.deadline_at = deadline_at
 
     @property
     def timeout(self) -> float:

--- a/aio_request/deadline.py
+++ b/aio_request/deadline.py
@@ -4,7 +4,7 @@ import datetime
 class Deadline:
     @staticmethod
     def from_timeout(seconds: float) -> "Deadline":
-        return Deadline(datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds))
+        return Deadline(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=seconds))
 
     @staticmethod
     def try_parse(value: str | None) -> "Deadline | None":
@@ -27,11 +27,13 @@ class Deadline:
 
     @property
     def timeout(self) -> float:
-        return max((self.deadline_at - datetime.datetime.utcnow()).total_seconds(), 0.001)  # 0 is infinite
+        return max(
+            (self.deadline_at - datetime.datetime.now(datetime.timezone.utc)).total_seconds(), 0.001
+        )  # 0 is infinite
 
     @property
     def expired(self) -> bool:
-        return (self.deadline_at - datetime.datetime.utcnow()).total_seconds() <= 0
+        return (self.deadline_at - datetime.datetime.now(datetime.timezone.utc)).total_seconds() <= 0
 
     def __repr__(self) -> str:
         return f"<Deadline [{self.deadline_at.isoformat()}]>"

--- a/tests/test_deadline.py
+++ b/tests/test_deadline.py
@@ -17,7 +17,7 @@ async def test_deadline_expired():
 
 async def test_invalid_deadline_at():
     with pytest.raises(RuntimeError):
-        aio_request.Deadline(datetime.datetime.utcnow().replace(tzinfo=zoneinfo.ZoneInfo("UTC")))
+        aio_request.Deadline(datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=zoneinfo.ZoneInfo("UTC")))
 
 
 async def test_parse_str():

--- a/tests/test_deadline.py
+++ b/tests/test_deadline.py
@@ -2,8 +2,6 @@ import asyncio
 import datetime
 import zoneinfo
 
-import pytest
-
 import aio_request
 
 
@@ -15,9 +13,34 @@ async def test_deadline_expired():
     assert deadline.expired
 
 
-async def test_invalid_deadline_at():
-    with pytest.raises(RuntimeError):
-        aio_request.Deadline(datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=zoneinfo.ZoneInfo("UTC")))
+async def test_no_timezone_deadline_at():
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    deadline = aio_request.Deadline(now + datetime.timedelta(seconds=1))
+    assert not deadline.expired
+    assert 0.5 < deadline.timeout < 1.0
+
+
+async def test_utc_timezone_deadline_at_1():
+    now = datetime.datetime.now(datetime.timezone.utc)
+    deadline = aio_request.Deadline(now + datetime.timedelta(seconds=1))
+    assert not deadline.expired
+    assert 0.5 < deadline.timeout < 1.0
+
+
+async def test_utc_timezone_deadline_at_2():
+    utc_timezone = zoneinfo.ZoneInfo("UTC")
+    now = datetime.datetime.now(utc_timezone)
+    deadline = aio_request.Deadline(now + datetime.timedelta(seconds=1))
+    assert not deadline.expired
+    assert 0.5 < deadline.timeout < 1.0
+
+
+async def test_los_angeles_timezone_deadline():
+    los_angeles_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")
+    now = datetime.datetime.now(los_angeles_timezone)
+    deadline = aio_request.Deadline(now + datetime.timedelta(seconds=1))
+    assert not deadline.expired
+    assert 0.5 < deadline.timeout < 1.0
 
 
 async def test_parse_str():


### PR DESCRIPTION
Also, it allow to provide datetime in any timezone (and naive will be used as UTC one).