### PR TITLE
Final refactoring of request enrichers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * Deprecation of MetricsProvider interface. For the backward compatibility, prometheus-client is conditionally imported. To use it, install prometheus-client. Related PRs: [#271](https://github.com/anna-money/aio-request/pull/271), [#218](https://github.com/anna-money/aio-request/pull/218), [#268](https://github.com/anna-money/aio-request/pull/268)
 * [Removal of unused Client interface](https://github.com/anna-money/aio-request/commit/fe75660af8e7520a6fa5143f982c5aacd2ea079a)
 * [Do not retry low timeout response](https://github.com/anna-money/aio-request/pull/276)
-* [Merge setup functions](https://github.com/anna-money/aio-request/pull/277)
-* [Fix request enrichers backward compatibility](https://github.com/anna-money/aio-request/pull/282)
+* Refactoring around request enrichers and deprecation of setup_v2. Related PRs: [#277](https://github.com/anna-money/aio-request/pull/277), [#282](https://github.com/anna-money/aio-request/pull/282), [#285](https://github.com/anna-money/aio-request/pull/285)
 * [Deadline provider for sequential strategy](https://github.com/anna-money/aio-request/pull/284)
 
 

--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -24,7 +24,7 @@ from .pipeline import BypassModule, LowTimeoutModule, NextModuleFunc, RequestMod
 from .priority import Priority
 from .request import (
     AsyncRequestEnricher,
-    AsyncRequestEnricherV2,
+    DeprecatedAsyncRequestEnricher,
     RequestEnricher,
     delete,
     get,
@@ -113,6 +113,7 @@ __all__: tuple[str, ...] = (
     "put_json",
     "RequestEnricher",
     "AsyncRequestEnricher",
+    "DeprecatedAsyncRequestEnricher",
     # request_strategy.py
     "MethodBasedStrategy",
     "ParallelRequestStrategy",

--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -23,8 +23,9 @@ from .endpoint_provider import DelegateEndpointProvider, EndpointProvider, Stati
 from .pipeline import BypassModule, LowTimeoutModule, NextModuleFunc, RequestModule, TransportModule, build_pipeline
 from .priority import Priority
 from .request import (
+    AsyncRequestEnricher,
+    AsyncRequestEnricherV2,
     RequestEnricher,
-    SimpleRequestEnricher,
     delete,
     get,
     patch,
@@ -110,8 +111,8 @@ __all__: tuple[str, ...] = (
     "post_json",
     "put",
     "put_json",
-    "SimpleRequestEnricher",
     "RequestEnricher",
+    "AsyncRequestEnricher",
     # request_strategy.py
     "MethodBasedStrategy",
     "ParallelRequestStrategy",

--- a/aio_request/endpoint_provider.py
+++ b/aio_request/endpoint_provider.py
@@ -33,8 +33,10 @@ class DelegateEndpointProvider(EndpointProvider):
         self.__endpoint_delegate = endpoint_delegate
 
     async def get(self) -> yarl.URL:
-        result = self.__endpoint_delegate()
-        return ensure_url(await result if asyncio.iscoroutine(result) else result)  # type: ignore
+        endpoint = self.__endpoint_delegate()
+        if asyncio.iscoroutine(endpoint):
+            endpoint = await endpoint
+        return ensure_url(endpoint)  # type: ignore
 
 
 def ensure_url(endpoint: str | yarl.URL) -> yarl.URL:

--- a/aio_request/request.py
+++ b/aio_request/request.py
@@ -9,7 +9,7 @@ from .base import MAX_REDIRECTS, Header, Headers, Method, PathParameters, QueryP
 
 RequestEnricher = collections.abc.Callable[[Request], Request]
 AsyncRequestEnricher = collections.abc.Callable[[Request], collections.abc.Awaitable[Request]]
-AsyncRequestEnricherV2 = collections.abc.Callable[[Request, bool], collections.abc.Awaitable[Request]]
+DeprecatedAsyncRequestEnricher = collections.abc.Callable[[Request, bool], collections.abc.Awaitable[Request]]
 
 
 def get(

--- a/aio_request/request.py
+++ b/aio_request/request.py
@@ -7,8 +7,9 @@ import yarl
 
 from .base import MAX_REDIRECTS, Header, Headers, Method, PathParameters, QueryParameters, Request
 
-SimpleRequestEnricher = collections.abc.Callable[[Request], Request]
-RequestEnricher = collections.abc.Callable[[Request, bool], collections.abc.Awaitable[Request]]
+RequestEnricher = collections.abc.Callable[[Request], Request]
+AsyncRequestEnricher = collections.abc.Callable[[Request], collections.abc.Awaitable[Request]]
+AsyncRequestEnricherV2 = collections.abc.Callable[[Request, bool], collections.abc.Awaitable[Request]]
 
 
 def get(

--- a/aio_request/setup.py
+++ b/aio_request/setup.py
@@ -1,4 +1,3 @@
-import asyncio
 import warnings
 from typing import Any
 
@@ -12,7 +11,7 @@ from .deprecated import MetricsProvider
 from .endpoint_provider import EndpointProvider, StaticEndpointProvider
 from .pipeline import BypassModule, CircuitBreakerModule, LowTimeoutModule, TransportModule, build_pipeline
 from .priority import Priority
-from .request import Request, RequestEnricher, SimpleRequestEnricher
+from .request import AsyncRequestEnricher, AsyncRequestEnricherV2, Request, RequestEnricher
 from .request_strategy import MethodBasedStrategy, RequestStrategy, sequential_strategy, single_attempt_strategy
 from .response_classifier import DefaultResponseClassifier, ResponseClassifier
 from .transport import Transport
@@ -20,7 +19,7 @@ from .transport import Transport
 MISSING: Any = object()
 
 
-def setup_v2(
+def setup(
     *,
     transport: Transport,
     endpoint: str | yarl.URL = MISSING,
@@ -34,7 +33,7 @@ def setup_v2(
     priority: Priority = Priority.NORMAL,
     low_timeout_threshold: float = 0.005,
     emit_system_headers: bool = True,
-    request_enricher: SimpleRequestEnricher | RequestEnricher | None = None,
+    request_enricher: RequestEnricher | AsyncRequestEnricher | None = None,
     metrics_provider: MetricsProvider | None = None,
     circuit_breaker: CircuitBreaker[yarl.URL, ClosableResponse] | None = None,
 ) -> Client:
@@ -78,24 +77,22 @@ def setup_v2(
                 TransportModule(
                     transport,
                     emit_system_headers=emit_system_headers,
-                    request_enricher=_get_enricher(request_enricher),
+                    request_enricher=request_enricher,
                 ),
             ],
         ),
     )
 
 
-def _get_enricher(enricher: SimpleRequestEnricher | RequestEnricher | None) -> RequestEnricher | None:
-    if enricher is None:
-        return None
+def setup_v2(*, request_enricher: AsyncRequestEnricherV2 | None = None, **kwargs: Any) -> Client:
+    warnings.warn(
+        "setup_v2 is deprecated, please use setup",
+        DeprecationWarning,
+    )
 
-    if asyncio.iscoroutinefunction(enricher):
-        return enricher
+    async def _patched_enricher(r: Request) -> Request:
+        if request_enricher is None:
+            return r
+        return await request_enricher(r, False)
 
-    async def _async_enricher(r: Request, _: bool) -> Request:
-        return enricher(r)  # type: ignore
-
-    return _async_enricher
-
-
-setup = setup_v2
+    return setup(request_enricher=_patched_enricher, **kwargs)

--- a/aio_request/setup.py
+++ b/aio_request/setup.py
@@ -11,7 +11,7 @@ from .deprecated import MetricsProvider
 from .endpoint_provider import EndpointProvider, StaticEndpointProvider
 from .pipeline import BypassModule, CircuitBreakerModule, LowTimeoutModule, TransportModule, build_pipeline
 from .priority import Priority
-from .request import AsyncRequestEnricher, AsyncRequestEnricherV2, Request, RequestEnricher
+from .request import AsyncRequestEnricher, DeprecatedAsyncRequestEnricher, Request, RequestEnricher
 from .request_strategy import MethodBasedStrategy, RequestStrategy, sequential_strategy, single_attempt_strategy
 from .response_classifier import DefaultResponseClassifier, ResponseClassifier
 from .transport import Transport
@@ -84,7 +84,7 @@ def setup(
     )
 
 
-def setup_v2(*, request_enricher: AsyncRequestEnricherV2 | None = None, **kwargs: Any) -> Client:
+def setup_v2(*, request_enricher: DeprecatedAsyncRequestEnricher | None = None, **kwargs: Any) -> Client:
     warnings.warn(
         "setup_v2 is deprecated, please use setup",
         DeprecationWarning,


### PR DESCRIPTION
It looks like nobody truly uses a version of enrichers with a signature `def enrich(request, emit_system_headers)`, so it makes sense to deprecate it along with setup_v2, because it is only place where it is used.