### PR TITLE
Transport metrics to track individual requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [Increase metrics buckets precision](https://github.com/anna-money/aio-request/pull/287)
 * [Expose methods to build requests](https://github.com/anna-money/aio-request/pull/288)
+* [Transport metrics to track individual requests](https://github.com/anna-money/aio-request/pull/289)
 
 
 ## v0.2.0 (2025-01-09)

--- a/aio_request/client.py
+++ b/aio_request/client.py
@@ -18,7 +18,7 @@ try:
 
     latency_histogram = prom.Histogram(
         "aio_request_latency",
-        "Duration of HTTP client requests.",
+        "Duration of client requests.",
         labelnames=(
             "request_endpoint",
             "request_method",


### PR DESCRIPTION
@maradik has asked to support that to track external services SLA violations per request.