### PR TITLE
json() should return None if response body is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* [Now json() could parse empty body when using httpx transport](https://github.com/anna-money/aio-request/pull/296)
+
 ## v0.2.1 (2025-01-09)
 
 * [Increase metrics buckets precision](https://github.com/anna-money/aio-request/pull/287)

--- a/aio_request/httpx.py
+++ b/aio_request/httpx.py
@@ -150,8 +150,14 @@ class _HttpxResponse(ClosableResponse):
             response_content_type = self.__response.headers.get(Header.CONTENT_TYPE, "").lower()
             if not is_expected_content_type(response_content_type, content_type):
                 raise UnexpectedContentTypeError(f"Expected {content_type}, actual {response_content_type}")
+        body = await self.__response.aread()
+        stripped = body.strip()
+        if not stripped:
+            return None
 
-        return loads(await self.text(encoding=encoding))
+        return loads(
+            stripped.decode(encoding or self.__response.charset_encoding or detect_encoding(stripped) or "utf-8")
+        )
 
     async def read(self) -> bytes:
         return await self.__response.aread()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -73,6 +73,30 @@ async def test_json(httpbin, transport):
         await response.close()
 
 
+async def test_json_empty_response(httpbin, transport):
+    response = await transport.send(
+        yarl.URL(httpbin.url),
+        aio_request.post("status/200"),
+        DEFAULT_TIMEOUT,
+    )
+    try:
+        assert response.status == 200
+        assert await response.json(content_type=None) == None
+        assert response.headers == multidict.CIMultiDict[str](
+            {
+                "Date": unittest.mock.ANY,
+                "Server": "Pytest-HTTPBIN/0.1.0",
+                "Content-Type": "text/html; charset=utf-8",
+                "Content-Length": "0",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Credentials": "true",
+                "Connection": "Close",
+            }
+        )
+    finally:
+        await response.close()
+
+
 async def test_utf8_text(httpbin, transport):
     response = await transport.send(
         yarl.URL(httpbin.url),

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -81,15 +81,16 @@ async def test_json_empty_response(httpbin, transport):
     )
     try:
         assert response.status == 200
-        assert await response.json(content_type=None) == None
-        assert response.headers == multidict.CIMultiDict[str](
+        assert await response.json(content_type=None) is None
+        headers = response.headers
+        assert headers == multidict.CIMultiDict[str](
             {
                 "Date": unittest.mock.ANY,
                 "Server": "Pytest-HTTPBIN/0.1.0",
                 "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": "0",
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Credentials": "true",
+                "Content-Length": "0",
                 "Connection": "Close",
             }
         )


### PR DESCRIPTION
json() fails with
```
  File "/usr/local/lib/python3.11/site-packages/aio_request/httpx.py", line 154, in json
    return loads(await self.text(encoding=encoding))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
```

if response body is empty when using httpx transport

After this fix `json()` will return `None` for empty body